### PR TITLE
Signal completion of the serve task

### DIFF
--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -48,13 +48,14 @@ function copyBinaryAssets() {
 /**
  * Serve the static docs directory over localhost
  */
-function serve() {
+function serve(signalDone) {
   connect.server({
     host: '0.0.0.0',
     livereload: true,
     port: 3000,
     root: config.dest,
   });
+  signalDone();
 }
 
 /**


### PR DESCRIPTION
## Description

### Steps to reproduce
- Run `npm start`
- Wait until the `Running server` message appears
- Stop the process by pressing Ctrl+C

### Expected outcome
No error messages

### Actual outcome

The following appears in red text

```
The following tasks did not complete: default, <parallel>, docs:serve, <parallel>, serve
Did you forget to signal async completion?
```

### Change

Use [an error first callback](https://gulpjs.com/docs/en/getting-started/async-completion/#using-an-error-first-callback) to signal that the task has finished after setting up the server.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
