### PR TITLE
Tell git to keep `lf` line endings in js files to avoid eslint errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.js text eol=lf


### PR DESCRIPTION
## Description

When the repository is downloaded to Windows if the `core.autocrlf` setting is set to `true` in the git global config then line endings are converted to `crlf` or `\r\n`.
When pushed back to the repo they are automatically converted back to `lf`, but on the Windows machine the eslint `linebreak-style` error (below) will be triggered on every line in every `*.js` file.

```
Expected linebreaks to be 'LF' but found 'CRLF'. eslint([linebreak-style](https://eslint.org/docs/rules/linebreak-style))
```

This is very noisy in editors that automatically show eslint errors, e.g.
![image](https://user-images.githubusercontent.com/6189323/219629798-2f82c74e-12ec-4d95-abde-286772334008.png)

Add a `.gitattributes` file which instructs git to keep the `lf` line endings even on windows.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
